### PR TITLE
Update go_hw0_test.yml to v3 instead of v2 artifact

### DIFF
--- a/.github/workflows/go_hw0_test.yml
+++ b/.github/workflows/go_hw0_test.yml
@@ -55,14 +55,14 @@ jobs:
 
       # Upload formatted logs
       - name: Upload unit test log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: unit-test-hw0-log
           path: ./${{ github.run_attempt }}/gotest-unit.log
           if-no-files-found: error
 
       - name: Upload integration test log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: integration-test-hw0-log
           path: ./${{ github.run_attempt }}/gotest-inte.log


### PR DESCRIPTION
Hello,
The v2 version of the artifact seems to have a problem and not run on any of my colleagues and my GitHub account because it's deprecated. I haven't advanced in the homework, but I have found that just replacing v2 to v3 in two lines seems to fix the problem and run the CI correctly.
Best regards 